### PR TITLE
chore: simplify configuration and enhance automerge settings

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,18 +8,6 @@
     ":pinDependencies",
     ":semanticCommits"
   ],
-  "ignorePresets": [
-    ":ignorePaths"
-  ],
-  "ignorePaths": [
-    "**/node_modules/**",
-    "**/bower_components/**",
-    "**/vendor/**",
-    "**/__tests__/**",
-    "**/test/**",
-    "**/tests/**",
-    "**/__fixtures__/**"
-  ],
   "baseBranches": [
     "main"
   ],
@@ -27,11 +15,10 @@
   "labels": [
     "dependencies"
   ],
+  "automergeStrategy": "squash",
+  "automergeType": "pr",
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
-  "pre-commit": {
-    "enabled": true
-  },
   "kubernetes": {
     "fileMatch": [
       "k8s/.+\\.yaml$",
@@ -41,20 +28,43 @@
   "hermit": {
     "enabled": true
   },
+  "pre-commit": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "matchManagers": [
-        "dockerfile",
         "kubernetes",
-        "pre-commit"
+        "pre-commit",
+        "dockerfile",
+        "github-actions",
+        "golang"
       ],
       "matchUpdateTypes": [
         "minor",
         "patch",
-        "digest"
+        "digest",
+        "pinDigest"
       ],
-      "automerge": true,
-      "automergeType": "pr"
+      "automerge": true
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false
+    },
+    {
+      "extends": [
+        "monorepo:aws-sdk-go-v2"
+      ],
+      "groupName": "aws-sdk-go-v2 monorepo"
     }
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
Remove deprecated ignore paths from default.json and simplify 
packageRules for better clarity. Introduce a new automerge strategy 
and type to streamline pull request handling. Additionally, add 
support for specific manager configurations to ensure precise 
automerge behavior, enhancing the overall package management 
process.