### PR TITLE
feat: enable OSV vulnerability alerts

### DIFF
--- a/default.json
+++ b/default.json
@@ -66,5 +66,13 @@
   ],
   "postUpdateOptions": [
     "gomodTidy"
-  ]
+  ],
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": [
+      "dependencies",
+      "security"
+    ]
+  }
 }


### PR DESCRIPTION
## What
Add `osvVulnerabilityAlerts: true` and an explicit `vulnerabilityAlerts` block (labels `dependencies`, `security`) to the shared preset.

## Why
Renovate's gomod manager skips `// indirect` deps by default, so vulns in indirect Go modules (e.g. `golang.org/x/net`) flagged by govulncheck never get a PR — only direct deps (e.g. `golang.org/x/crypto`) are bumped. `osvVulnerabilityAlerts` makes Renovate query the OSV database (same source as govulncheck) and raise security PRs for vulnerable deps **including indirect modules**, across every repo extending this preset.

## Verified
Local dry-run (`renovate --platform=local --dry-run=full`) against build-tools detected and set remediation targets matching govulncheck:
- `golang.org/x/crypto` → >= 0.52.0
- `golang.org/x/net` (indirect) → >= 0.55.0

Replaces the per-repo change originally opened as buildtool/build-tools#1500 (now closed).