### PR TITLE
feat: enable indirect Go module updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -50,6 +50,15 @@
     },
     {
       "matchManagers": [
+        "gomod"
+      ],
+      "matchDepTypes": [
+        "indirect"
+      ],
+      "enabled": true
+    },
+    {
+      "matchManagers": [
         "github-actions"
       ],
       "matchUpdateTypes": [


### PR DESCRIPTION
## What
Add a packageRule enabling `gomod` updates for `indirect` deps.

## Why
Follow-up to #44. A real Renovate run on build-tools showed `osvVulnerabilityAlerts` **detects** the indirect x/net vuln and sets the allowed range (>= 0.55.0), but the dep is dropped before any PR:
```
depName: golang.org/x/net  depType: indirect
enabled: false  skipReason: disabled  updates: []
```
Renovate's gomod manager disables `// indirect` deps by default, and that filter runs before vuln remediation. Per the [gomod docs](https://docs.renovatebot.com/modules/manager/gomod/), the only way to remediate indirect modules is to enable them.

## Effect
- Indirect Go vulns (e.g. x/net) now reach a security PR.
- Routine indirect bumps are auto-merged by the existing minor/patch/digest rule; vuln fixes carry the `security` label.
- Org-wide via this preset.